### PR TITLE
Make it easier to configure trace target with separate envvars

### DIFF
--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/CustomLogManagerTest.groovy
@@ -26,7 +26,7 @@ class CustomLogManagerTest extends Specification {
     expect:
     agentArg != null
     IntegrationTestUtils.runOnSeparateJvm(LogManagerSetter.getName()
-      , [agentArg, "-javaagent:" + customAgent.getPath(), "-Ddd.jmxfetch.enabled=true"] as String[]
+      , [agentArg, "-javaagent:" + customAgent.getPath(), "-Dsfx.jmxfetch.enabled=true"] as String[]
       , "" as String[]
       , true) == 0
   }

--- a/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
+++ b/dd-java-agent-ittests/src/test/groovy/datadog/trace/agent/JMXFetchTest.groovy
@@ -18,10 +18,10 @@ class JMXFetchTest extends Specification {
     def currentContextLoader = Thread.currentThread().getContextClassLoader()
     DatagramSocket socket = new DatagramSocket(0)
 
-    System.properties.setProperty("dd.jmxfetch.enabled", "true")
-    System.properties.setProperty("dd.jmxfetch.statsd.port", Integer.toString(socket.localPort))
+    System.properties.setProperty("sfx.jmxfetch.enabled", "true")
+    System.properties.setProperty("sfx.jmxfetch.statsd.port", Integer.toString(socket.localPort))
     // Overwrite writer type to disable console jmxfetch reporter
-    System.properties.setProperty("dd.writer.type", "DDAgentWriter")
+    System.properties.setProperty("sfx.writer.type", "DDAgentWriter")
 
     def classLoader = IntegrationTestUtils.getJmxFetchClassLoader()
     // Have to set this so JMXFetch knows where to find resources

--- a/dd-trace-api/src/main/java/datadog/trace/api/Config.java
+++ b/dd-trace-api/src/main/java/datadog/trace/api/Config.java
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 @ToString(includeFieldNames = true)
 public class Config {
   /** Config keys below */
-  private static final String PREFIX = "dd.";
+  private static final String PREFIX = "sfx.";
 
   private static final Config INSTANCE = new Config();
 
@@ -32,6 +32,7 @@ public class Config {
   public static final String WRITER_TYPE = "writer.type";
   public static final String AGENT_HOST = "agent.host";
   public static final String TRACE_AGENT_PORT = "trace.agent.port";
+  public static final String AGENT_PATH = "agent.path";
   public static final String AGENT_PORT_LEGACY = "agent.port";
   public static final String PRIORITY_SAMPLING = "priority.sampling";
   public static final String TRACE_RESOLVER_ENABLED = "trace.resolver.enabled";
@@ -57,7 +58,8 @@ public class Config {
   public static final String DEFAULT_AGENT_WRITER_TYPE = DD_AGENT_WRITER_TYPE;
 
   public static final String DEFAULT_AGENT_HOST = "localhost";
-  public static final int DEFAULT_TRACE_AGENT_PORT = 8126;
+  public static final int DEFAULT_TRACE_AGENT_PORT = 9080;
+  public static final String DEFAULT_AGENT_PATH = "/v1/trace";
 
   private static final boolean DEFAULT_RUNTIME_CONTEXT_FIELD_INJECTION = false;
 
@@ -77,6 +79,7 @@ public class Config {
   @Getter private final String writerType;
   @Getter private final String agentHost;
   @Getter private final int agentPort;
+  @Getter private final String agentPath;
   @Getter private final boolean prioritySamplingEnabled;
   @Getter private final boolean traceResolverEnabled;
   @Getter private final Map<String, String> serviceMapping;
@@ -104,6 +107,7 @@ public class Config {
         getIntegerSettingFromEnvironment(
             TRACE_AGENT_PORT,
             getIntegerSettingFromEnvironment(AGENT_PORT_LEGACY, DEFAULT_TRACE_AGENT_PORT));
+    agentPath = getSettingFromEnvironment(AGENT_PATH, DEFAULT_AGENT_PATH);
     prioritySamplingEnabled =
         getBooleanSettingFromEnvironment(PRIORITY_SAMPLING, DEFAULT_PRIORITY_SAMPLING_ENABLED);
     traceResolverEnabled =
@@ -142,6 +146,7 @@ public class Config {
             properties,
             TRACE_AGENT_PORT,
             getPropertyIntegerValue(properties, AGENT_PORT_LEGACY, parent.agentPort));
+    agentPath = properties.getProperty(AGENT_PATH, parent.agentPath);
     prioritySamplingEnabled =
         getPropertyBooleanValue(properties, PRIORITY_SAMPLING, parent.prioritySamplingEnabled);
     traceResolverEnabled =

--- a/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
+++ b/dd-trace-api/src/test/groovy/datadog/trace/api/ConfigTest.groovy
@@ -13,14 +13,14 @@ class ConfigTest extends Specification {
   @Rule
   public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
-  private static final DD_SERVICE_NAME_ENV = "DD_SERVICE_NAME"
-  private static final DD_WRITER_TYPE_ENV = "DD_WRITER_TYPE"
-  private static final DD_SERVICE_MAPPING_ENV = "DD_SERVICE_MAPPING"
-  private static final DD_SPAN_TAGS_ENV = "DD_SPAN_TAGS"
-  private static final DD_HEADER_TAGS_ENV = "DD_HEADER_TAGS"
-  private static final DD_JMXFETCH_METRICS_CONFIGS_ENV = "DD_JMXFETCH_METRICS_CONFIGS"
-  private static final DD_TRACE_AGENT_PORT_ENV = "DD_TRACE_AGENT_PORT"
-  private static final DD_AGENT_PORT_LEGACY_ENV = "DD_AGENT_PORT"
+  private static final DD_SERVICE_NAME_ENV = "SFX_SERVICE_NAME"
+  private static final DD_WRITER_TYPE_ENV = "SFX_WRITER_TYPE"
+  private static final DD_SERVICE_MAPPING_ENV = "SFX_SERVICE_MAPPING"
+  private static final DD_SPAN_TAGS_ENV = "SFX_SPAN_TAGS"
+  private static final DD_HEADER_TAGS_ENV = "SFX_HEADER_TAGS"
+  private static final DD_JMXFETCH_METRICS_CONFIGS_ENV = "SFX_JMXFETCH_METRICS_CONFIGS"
+  private static final DD_TRACE_AGENT_PORT_ENV = "SFX_TRACE_AGENT_PORT"
+  private static final DD_AGENT_PORT_LEGACY_ENV = "SFX_AGENT_PORT"
 
   def "verify defaults"() {
     when:
@@ -30,7 +30,7 @@ class ConfigTest extends Specification {
     config.serviceName == "unnamed-java-app"
     config.writerType == "DDAgentWriter"
     config.agentHost == "localhost"
-    config.agentPort == 8126
+    config.agentPort == 9080
     config.prioritySamplingEnabled == true
     config.traceResolverEnabled == true
     config.serviceMapping == [:]
@@ -155,7 +155,7 @@ class ConfigTest extends Specification {
     true         | true               | false              | false                    | 123
     true         | false              | false              | false                    | 123
     false        | true               | false              | false                    | 456
-    false        | false              | false              | false                    | 8126
+    false        | false              | false              | false                    | 9080
     true         | true               | true               | false                    | 123
     true         | false              | true               | false                    | 123
     false        | true               | true               | false                    | 777 // env var gets picked up instead.


### PR DESCRIPTION
This is useful in environments like Kubernetes where you can get the node ip by itself

Also switching the config prefix to SFX_ from DD_