### PR TITLE
Add server span kind to jax-rs-controller spans

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsAnnotationsInstrumentation.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/main/java/datadog/trace/instrumentation/jaxrs/JaxRsAnnotationsInstrumentation.java
@@ -137,6 +137,7 @@ public final class JaxRsAnnotationsInstrumentation extends Instrumenter.Default 
 
       return GlobalTracer.get()
           .buildSpan(operationName)
+          .withTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_SERVER)
           .withTag(Tags.COMPONENT.getKey(), "jax-rs-controller")
           .startActive(true);
     }

--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/test/groovy/JaxRsAnnotationsInstrumentationTest.groovy
@@ -41,6 +41,7 @@ class JaxRsAnnotationsInstrumentationTest extends AgentTestRunner {
           operationName "${className}.call"
           childOf span(0)
           tags {
+            "$Tags.SPAN_KIND.key" "$Tags.SPAN_KIND_SERVER"
             "$Tags.COMPONENT.key" "jax-rs-controller"
             defaultTags()
           }


### PR DESCRIPTION
For uninstrumented servers, having the first traced operation at the controller level use this span kind will be informative.