### PR TITLE
Tag jax-rs parent spans upon error

### DIFF
--- a/dd-java-agent/instrumentation/jax-rs-annotations/src/main/java/datadog/trace/instrumentation/jaxrs/utils/ScopeStore.java
+++ b/dd-java-agent/instrumentation/jax-rs-annotations/src/main/java/datadog/trace/instrumentation/jaxrs/utils/ScopeStore.java
@@ -1,0 +1,17 @@
+package datadog.trace.instrumentation.jaxrs.utils;
+
+import io.opentracing.Scope;
+
+/**
+ * A mechanism to store a Scope and flag for whether it should be closed upon stopSpan cleanup for
+ * controller and parent spans created by jax-rs-annotation instrumentation.
+ */
+public class ScopeStore {
+  public final Scope scope;
+  public final boolean close;
+
+  public ScopeStore(final Scope scope, final boolean close) {
+    this.scope = scope;
+    this.close = close;
+  }
+}


### PR DESCRIPTION
In cases where an exception is thrown in a JAX-RS controller, it can be advantageous not just marking the controller span as having errored.  These changes set the error tag for both controller and parent spans, but still log the exception object in the controller span.

Also includes a new `ScopeStore` class for marshaling scopes and whether they should be closed upon cleanup across byte buddy enter/exit methods to avoid prematurely closing spans not created by the instrumentation.